### PR TITLE
Add burdock link in conda.ymls(to latest master), add sql module tests, and fix PSI mechanism bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 # mlflow
 mlruns
+result.json

--- a/sdk/burdock/mechanisms/laplace.py
+++ b/sdk/burdock/mechanisms/laplace.py
@@ -1,12 +1,13 @@
 import numpy as np
 
+
 class Laplace:
-    def __init__(self, epsilon, tau):
+    def __init__(self, epsilon, tau=5):
         self.epsilon = epsilon
         self.tau = tau
 
     def count(self, vals):
-        noise = np.random.normal(0.0, self.tau / self.epsilon, len(vals) )
+        noise = np.random.normal(0.0, self.tau / self.epsilon, len(vals))
         new_vals = noise + vals
         return new_vals
 

--- a/service/modules/psi-count-module/conda.yaml
+++ b/service/modules/psi-count-module/conda.yaml
@@ -4,3 +4,5 @@ channels:
 dependencies:
   - pip:
     - mlflow
+    - pandas
+    - git+https://git.repo/some_repo.git#egg=version_subpkg&subdirectory=repo

--- a/service/modules/psi-count-module/statistic.py
+++ b/service/modules/psi-count-module/statistic.py
@@ -82,7 +82,8 @@ class Count(Computer):
         num_obs = dataset.shape[0]
         # obfuscate the count
         sens = 2
-        counts = Laplace(self._epsilon).count([num_obs])
+        tau = 5
+        counts = Laplace(self._epsilon, tau).count([num_obs])
         count_release = counts[0]
 
         # calculate accuracy from epsilon

--- a/service/modules/psi-count-module/statistic.py
+++ b/service/modules/psi-count-module/statistic.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 import math
 import logging
-from burdock.mechanisms.laplace import evaluate
+from burdock.mechanisms.laplace import Laplace
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +82,9 @@ class Count(Computer):
         num_obs = dataset.shape[0]
         # obfuscate the count
         sens = 2
-        noise = evaluate(sens, self._epsilon)
-        count_release = num_obs + noise
+        counts = Laplace(self._epsilon).count([num_obs])
+        count_release = counts[0]
+
         # calculate accuracy from epsilon
         accuracy = self._compute_accuracy(self._epsilon)
         accuracy_bound = accuracy * num_obs

--- a/service/modules/sql-module/conda.yaml
+++ b/service/modules/sql-module/conda.yaml
@@ -5,3 +5,5 @@ dependencies:
   - pip:
     - mlflow
     - pandasql
+    - pandas
+    - git+https://git.repo/some_repo.git#egg=version_subpkg&subdirectory=repo

--- a/service/modules/sql-module/result.json
+++ b/service/modules/sql-module/result.json
@@ -1,4 +1,0 @@
-{"original_query": "SELECT COUNT ( A ) FROM example.example",
-"final_query": "SELECT ( SUM ( count_A ) ) FROM ( SELECT COUNT ( DISTINCT A ) AS keycount, ( SUM ( count_A ) ) AS count_A FROM ( SELECT *, ROW_NUMBER ( ) OVER ( PARTITION BY A ORDER BY RANDOM ( ) ) AS row_num FROM ( SELECT A AS A, COUNT ( A ) AS count_A FROM ( SELECT A AS A FROM example.example ) AS clamped GROUP BY A ) AS per_key_clamped ) AS per_key_random WHERE per_key_random.row_num <= 5 ) AS exact_aggregates", 
-"query_result": {"COUNT ( A )": {"0": 1}},
-"final_query_result": {"( SUM ( count_A ) )": {"0": 1}}}

--- a/service/modules/sql-module/run_query.py
+++ b/service/modules/sql-module/run_query.py
@@ -9,14 +9,13 @@ from pandasql import sqldf
 
 
 if __name__ == "__main__":
-    dataset_name = sys.argv[1] if len(sys.argv) > 1 else "example"
+    dataset_name = sys.argv[1]
     budget = float(sys.argv[2])
     query = sys.argv[3]
 
     with mlflow.start_run():
         dataset_document = get_dataset_client().read(dataset_name, budget)
         df_for_diffpriv1234 = load_dataset(dataset_document)
-        import pdb; pdb.set_trace()
         df_name = "df_for_diffpriv1234"
         metadata = load_metadata(dataset_document)
         q = QueryParser(metadata).query(query)

--- a/tests/service/execute/test_smoke.py
+++ b/tests/service/execute/test_smoke.py
@@ -1,10 +1,9 @@
-import json
-
 import pytest
 
 @pytest.mark.parametrize("project", [{"params": {"text": "this text"}, "uri": "modules/module-example"},
-                                     {"dataset_name": "example", "budget": .2,
+                                     {"params": {"dataset_name": "example", "budget": .2,
                                       "query": "SELECT COUNT(*) FROM example.example"},
+                                      "uri": "modules/sql-module"},
                                      {"params": {"dataset_name": "example", "column_name": "a", "budget": .2},
                                       "uri": "modules/psi-count-module"}])
 def test_execute_run(execution_client, project):

--- a/tests/service/execute/test_smoke.py
+++ b/tests/service/execute/test_smoke.py
@@ -2,8 +2,9 @@ import json
 
 import pytest
 
-@pytest.mark.parametrize("project", [{"params": {"alpha": .4}, "uri": "https://github.com/mlflow/mlflow-example"},
-                                     {"params": {"text": "this text"}, "uri": "modules/module-example"},
+@pytest.mark.parametrize("project", [{"params": {"text": "this text"}, "uri": "modules/module-example"},
+                                     {"dataset_name": "example", "budget": .2,
+                                      "query": "SELECT COUNT(*) FROM example.example"},
                                      {"params": {"dataset_name": "example", "column_name": "a", "budget": .2},
                                       "uri": "modules/psi-count-module"}])
 def test_execute_run(execution_client, project):


### PR DESCRIPTION
- Add default for tau thresholding of 5, it was previously required upstream
- Temporarily add git link for mlflow modules to run against latest master bits
- Update PSI usage of Laplace to confirm to the new spec
- Add SQL module to the smoke tests
