### PR TITLE
Avoid early error for missing config values for dataverse

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,9 @@ def client():
 
     base_url = "http://localhost:{}/api/".format(port)
     client = RestClient(Credentials(), base_url)
-    client.secretsput(Secret(name="dataverse:{}".format("demo_dataverse"),
-                             value=os.environ[DATAVERSE_TOKEN_ENV_VAR]))
+    if DATAVERSE_TOKEN_ENV_VAR in os.environ:
+        client.secretsput(Secret(name="dataverse:{}".format("demo_dataverse"),
+                                 value=os.environ[DATAVERSE_TOKEN_ENV_VAR]))
     return client
 
 def test_client(client):


### PR DESCRIPTION
Fix error in tests without proper configuration.

Dataverse dependent tests fail without the environment variable, however, the failures will now be in the test as opposed to the test setup