### PR TITLE
Add option for service level overrides of mlflow server

### DIFF
--- a/sdk/burdock/data/dataset_adapter.py
+++ b/sdk/burdock/data/dataset_adapter.py
@@ -4,9 +4,6 @@ import requests
 
 import pandas as pd
 
-from burdock.query.sql import MetadataLoader
-from burdock.query.sql.reader import CSVReader
-
 
 class DatasetAdapter(object):
     KEY = "default"

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -1,0 +1,1 @@
+custom_mlflow_setup.py

--- a/service/app.py
+++ b/service/app.py
@@ -19,4 +19,10 @@ if __name__ == "__main__":
     parser.add_argument("--debug", type=bool, default=True, help="whether to run in debug mode")
     args = parser.parse_args()
 
+    try:
+        from custom_mlflow_setup import setup_mlflow
+        setup_mlflow()
+    except:
+        pass
+
     run_app(__name__, spec_file=args.spec, port=args.port, debug_mode=args.debug)

--- a/service/datasets/example.yaml
+++ b/service/datasets/example.yaml
@@ -2,16 +2,16 @@ Database:
   example:
     example:
       rows: 1
-      A:
+      a:
         type: int
         is_key: True
         min: 0
         max: 5
-      B:
+      b:
         type: int
         min: 0
         max: 25
-      C:
+      c:
         type: int
         min: 0
         max: 125

--- a/service/execute.py
+++ b/service/execute.py
@@ -6,6 +6,7 @@ from mlflow.tracking.client import MlflowClient
 
 
 def run(details):
+
     params = json.loads(details["params"])
     project_uri = details["project_uri"]
     if not(project_uri.startswith("http://") or project_uri.startswith("https://")):
@@ -16,7 +17,7 @@ def run(details):
     submitted_run = mlflow.projects.run(project_uri,
                                         parameters=params,
                                         use_conda=False)
-    path = MlflowClient().download_artifacts(submitted_run.run_id, ".")
-    with open(os.path.join(path, "result.json"), "r") as stream:
+    path = MlflowClient().download_artifacts(submitted_run.run_id, "result.json")
+    with open(path, "r") as stream:
         json_str = stream.read()
     return {"result": json.dumps(json.loads(json_str))}


### PR DESCRIPTION
- add support for overriding the mlflow tracking scenario. Exposes a hook for service deployers to modify the base mlflow server. Adds support for remote tracking servers