### PR TITLE
Pull through symbols for postprocess functions

### DIFF
--- a/sdk/burdock/query/sql/ast/ast.py
+++ b/sdk/burdock/query/sql/ast/ast.py
@@ -130,6 +130,8 @@ class Order(Sql):
         self.sortItems = Seq(sortItems)
     def children(self):
         return [Token("ORDER"), Token("BY"), self.sortItems]
+    def symbol(self, relations):
+        return Order(self.sortItems.symbol(relations))
 
 
 """

--- a/sdk/burdock/query/sql/ast/expression.py
+++ b/sdk/burdock/query/sql/ast/expression.py
@@ -14,6 +14,8 @@ class Expression(SqlExpr):
         return type(self) == type(other) and self.fragment == other.fragment
     def __hash__(self):
         return hash(self.fragment)
+    def symbol(self, relations):
+        raise ValueError("Cannot load symbol on bare expression: " + str(self))
 
 class NestedExpression(SqlExpr):
     """A nested expression with no name"""

--- a/sdk/burdock/query/sql/ast/expressions/logical.py
+++ b/sdk/burdock/query/sql/ast/expressions/logical.py
@@ -67,6 +67,8 @@ class PredicatedExpression(SqlExpr):
         self.predicate = predicate
     def children(self):
         return [self.expression, self.predicate]
+    def symbol(self, relations):
+        return PredicatedExpression(self.expression.symbol(relations), self.predicate.symbol(relations))
 
 class InCondition(SqlExpr):
     def __init__(self, expressions, is_not=False):

--- a/sdk/burdock/query/sql/ast/expressions/numeric.py
+++ b/sdk/burdock/query/sql/ast/expressions/numeric.py
@@ -48,8 +48,6 @@ class ArithmeticExpression(SqlExpr):
         self.left = left
         self.right = right
         self.op = op
-    def symbol(self, relations):
-        return ArithmeticExpression(self.left.symbol(relations), self.op, self.right.symbol(relations))
     def type(self):
         if self.op == "/":
             return "float"
@@ -93,6 +91,8 @@ class ArithmeticExpression(SqlExpr):
         l = self.left.evaluate(bindings)
         r = self.right.evaluate(bindings)
         return ops[self.op](l, r)
+    def symbol(self, relations):
+        return ArithmeticExpression(self.left.symbol(relations), self.op, self.right.symbol(relations))
 
 class MathFunction(SqlExpr):
     def __init__(self, name, expression):
@@ -118,6 +118,8 @@ class MathFunction(SqlExpr):
     def evaluate(self, bindings):
         exp = self.expression.evaluate(bindings)
         return funcs[self.name.lower()](exp)
+    def symbol(self, relations):
+        return MathFunction(self.name, self.expression.symbol(relations))
 
 class PowerFunction(SqlExpr):
     def __init__(self, expression, power):
@@ -130,6 +132,8 @@ class PowerFunction(SqlExpr):
     def evaluate(self, bindings):
         exp = self.expression.evaluate(bindings)
         return np.power(exp, self.power.value)
+    def symbol(self, relations):
+        return PowerFunction(self.expression.symbol(relations), self.power.symbol(relations))
 
 class BareFunction(SqlExpr):
     def __init__(self, name):
@@ -149,3 +153,5 @@ class RoundFunction(SqlExpr):
     def evaluate(self, bindings):
         exp = self.expression.evaluate(bindings)
         return np.round(exp, self.decimals.value)
+    def symbol(self, relations):
+        return RoundFunction(self.expression.symbol(relations), self.decimals)

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -106,3 +106,13 @@ class TestQuery:
         for i in range(3):
             trs = private_reader._postprocess(*pre)
             assert(len(trs) == 1)
+    def test_sum_noisy(self):
+        reader = DataFrameReader(schema, df)
+        query = QueryParser(schema).queries("SELECT SUM(age) as age_total FROM PUMS.PUMS")[0]
+        trs = reader.execute_typed(query)
+        assert(trs['age_total'][0] > 1000)
+    def test_sum_noisy_postprocess(self):
+        reader = DataFrameReader(schema, df)
+        private_reader = PrivateQuery(reader, schema, 1.0)
+        trs = private_reader.execute_typed("SELECT POWER(SUM(age), 2) as age_total FROM PUMS.PUMS")
+        assert(trs['age_total'][0] > 1000 ** 2)


### PR DESCRIPTION
Bug fix for #97.  Some post process functions were passing through without connecting to the source columns.  Fixed bug and added two new exceptions to catch any case where a function forgets to implement the symbol() call.  Added unit test.