### PR TITLE
Bias test

### DIFF
--- a/evaluation/dp_verification.py
+++ b/evaluation/dp_verification.py
@@ -392,7 +392,7 @@ class DPVerification:
         dp_res = np.all(np.array([res[0] for res in res_list]))
         acc_res = np.all(np.array([res[1] for res in res_list]))
         utility_res = np.all(np.array([res[2] for res in res_list]))
-        bias_res = np.all(np.array([res[3] for res in res_list]))
+        bias_res = np.all(np.array([res[4] for res in res_list]))
         return dp_res, acc_res, utility_res, bias_res
 
     # Use the powerset based neighboring datasets to scan through all edges of database search graph
@@ -432,6 +432,7 @@ class DPVerification:
         dp_res = np.all(np.array([res[0] for res in res_list.values()]))
         acc_res = np.all(np.array([res[1] for res in res_list.values()]))
         utility_res = np.all(np.array([res[2] for res in res_list.values()]))
+        bias_res = np.all(np.array([res[4] for res in res_list.values()]))
         return dp_res, acc_res, utility_res, bias_res
 
     # Main method listing all the DP verification steps

--- a/evaluation/dp_verification.py
+++ b/evaluation/dp_verification.py
@@ -326,7 +326,7 @@ class DPVerification:
         actual = [actual] * n
         msd = (np.sum(fD - actual) / n) / actual[0]
         print("Mean signed deviation: ", '%.4f'%(msd))
-        return (abs(msd) < 0.01), msd
+        return (abs(msd) < 0.05), msd
 
     # Applying queries repeatedly against SQL-92 implementation of Differential Privacy by Burdock
     def dp_query_test(self, d1_query, d2_query, debug=False, plot=True, bound=True, exact=False, repeat_count=10000, confidence=0.95, get_exact=True):

--- a/tests/evaluation/test_stochastic.py
+++ b/tests/evaluation/test_stochastic.py
@@ -93,7 +93,7 @@ class TestStochastic:
     def test_groupby(self):
         d1_query = "SELECT Role, Segment, COUNT(UserId) AS UserCount, SUM(Usage) AS Usage FROM d1.d1 GROUP BY Role, Segment"
         d2_query = "SELECT Role, Segment, COUNT(UserId) AS UserCount, SUM(Usage) AS Usage FROM d2.d2 GROUP BY Role, Segment"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=2000)
         test_logger.debug("Result of DP Predicate Test on GROUP BY and SUM, COUNT aggregate: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on GROUP BY and SUM, COUNT aggregate: " + str(acc_res))
         test_logger.debug("Result of Utility Test on GROUP BY and SUM, COUNT aggregate: " + str(utility_res))
@@ -106,7 +106,7 @@ class TestStochastic:
     def test_groupby_avg(self):
         d1_query = "SELECT Role, Segment, AVG(Usage) AS AvgUsage FROM d1.d1 GROUP BY Role, Segment"
         d2_query = "SELECT Role, Segment, AVG(Usage) AS AvgUsage FROM d2.d2 GROUP BY Role, Segment"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=2000)
         test_logger.debug("Result of DP Predicate Test on GROUP BY and AVG aggregate: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on GROUP BY and AVG aggregate: " + str(acc_res))
         test_logger.debug("Result of Utility Test on GROUP BY and AVG aggregate: " + str(utility_res))

--- a/tests/evaluation/test_stochastic.py
+++ b/tests/evaluation/test_stochastic.py
@@ -20,37 +20,40 @@ class TestStochastic:
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT COUNT(UserId) AS UserCount FROM d1.d1"
         d2_query = "SELECT COUNT(UserId) AS UserCount FROM d2.d2"
-        dp_res, acc_res, utility_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
         test_logger.debug("Result of DP Predicate Test on COUNT Query: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on COUNT Query: " + str(acc_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)
+        assert(bias_res == True)
 
     def test_dp_predicate_sum(self):
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT SUM(Usage) AS TotalUsage FROM d1.d1"
         d2_query = "SELECT SUM(Usage) AS TotalUsage FROM d2.d2"
-        dp_res, acc_res, utility_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
         test_logger.debug("Result of DP Predicate Test on SUM Query: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on SUM Query: " + str(acc_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)
+        assert(bias_res == True)
     
     def test_dp_predicate_mean(self):
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT AVG(Usage) AS MeanUsage FROM d1.d1"
         d2_query = "SELECT AVG(Usage) AS MeanUsage FROM d2.d2"
-        dp_res, acc_res, utility_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
         test_logger.debug("Result of DP Predicate Test on MEAN Query: " + str(dp_res))
         assert(dp_res == True)
+        assert(bias_res == True)
 
     def test_dp_predicate_var(self):
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT VAR(Usage) AS UsageVariance FROM d1.d1"
         d2_query = "SELECT VAR(Usage) AS UsageVariance FROM d2.d2"
-        dp_res, acc_res, utility_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500, get_exact=False)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500, get_exact=False)
         test_logger.debug("Result of DP Predicate Test on VAR Query: " + str(dp_res))
         assert(dp_res == True)
 
@@ -75,22 +78,24 @@ class TestStochastic:
     @pytest.mark.slow
     def test_powerset_sum(self):
         query_str = "SELECT SUM(Usage) AS TotalUsage FROM "
-        dp_res, acc_res, utility_res = dv.dp_powerset_test(query_str, repeat_count=500, plot=False)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_powerset_test(query_str, repeat_count=500, plot=False)
         test_logger.debug("Result of DP Predicate Test on Powerset SUM: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on Powerset SUM: " + str(acc_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)
+        assert(bias_res == True)
 
     def test_groupby(self):
         d1_query = "SELECT Role, Segment, COUNT(UserId) AS UserCount, SUM(Usage) AS Usage FROM d1.d1 GROUP BY Role, Segment"
         d2_query = "SELECT Role, Segment, COUNT(UserId) AS UserCount, SUM(Usage) AS Usage FROM d2.d2 GROUP BY Role, Segment"
-        dp_res, acc_res, utility_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=500)
         test_logger.debug("Result of DP Predicate Test on GROUP BY: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on GROUP BY: " + str(acc_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)
+        assert(bias_res == True)
 
     @pytest.mark.skip(reason="Yarrow response error while calling")
     def test_yarrow_dp_mean(self):

--- a/tests/evaluation/test_stochastic.py
+++ b/tests/evaluation/test_stochastic.py
@@ -20,9 +20,11 @@ class TestStochastic:
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT COUNT(UserId) AS UserCount FROM d1.d1"
         d2_query = "SELECT COUNT(UserId) AS UserCount FROM d2.d2"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
         test_logger.debug("Result of DP Predicate Test on COUNT Query: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on COUNT Query: " + str(acc_res))
+        test_logger.debug("Result of Utility Test on COUNT Query: " + str(utility_res))
+        test_logger.debug("Result of Bias Test on COUNT Query: " + str(bias_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)
@@ -32,9 +34,11 @@ class TestStochastic:
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT SUM(Usage) AS TotalUsage FROM d1.d1"
         d2_query = "SELECT SUM(Usage) AS TotalUsage FROM d2.d2"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
         test_logger.debug("Result of DP Predicate Test on SUM Query: " + str(dp_res))
         test_logger.debug("Result of Accuracy Test on SUM Query: " + str(acc_res))
+        test_logger.debug("Result of Utility Test on SUM Query: " + str(utility_res))
+        test_logger.debug("Result of Bias Test on SUM Query: " + str(bias_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)
@@ -44,7 +48,7 @@ class TestStochastic:
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT AVG(Usage) AS MeanUsage FROM d1.d1"
         d2_query = "SELECT AVG(Usage) AS MeanUsage FROM d2.d2"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
         test_logger.debug("Result of DP Predicate Test on MEAN Query: " + str(dp_res))
         assert(dp_res == True)
         assert(bias_res == True)
@@ -53,7 +57,7 @@ class TestStochastic:
         logging.getLogger().setLevel(logging.DEBUG)
         d1_query = "SELECT VAR(Usage) AS UsageVariance FROM d1.d1"
         d2_query = "SELECT VAR(Usage) AS UsageVariance FROM d2.d2"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=500, get_exact=False)
+        dp_res, acc_res, utility_res, bias_res = dv.dp_query_test(d1_query, d2_query, plot=False, repeat_count=1000, get_exact=False)
         test_logger.debug("Result of DP Predicate Test on VAR Query: " + str(dp_res))
         assert(dp_res == True)
 
@@ -89,9 +93,24 @@ class TestStochastic:
     def test_groupby(self):
         d1_query = "SELECT Role, Segment, COUNT(UserId) AS UserCount, SUM(Usage) AS Usage FROM d1.d1 GROUP BY Role, Segment"
         d2_query = "SELECT Role, Segment, COUNT(UserId) AS UserCount, SUM(Usage) AS Usage FROM d2.d2 GROUP BY Role, Segment"
-        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=500)
-        test_logger.debug("Result of DP Predicate Test on GROUP BY: " + str(dp_res))
-        test_logger.debug("Result of Accuracy Test on GROUP BY: " + str(acc_res))
+        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
+        test_logger.debug("Result of DP Predicate Test on GROUP BY and SUM, COUNT aggregate: " + str(dp_res))
+        test_logger.debug("Result of Accuracy Test on GROUP BY and SUM, COUNT aggregate: " + str(acc_res))
+        test_logger.debug("Result of Utility Test on GROUP BY and SUM, COUNT aggregate: " + str(utility_res))
+        test_logger.debug("Result of Bias Test on GROUP BY and SUM, COUNT aggregate: " + str(bias_res))
+        assert(dp_res == True)
+        assert(acc_res == True)
+        assert(utility_res == True)
+        assert(bias_res == True)
+
+    def test_groupby_avg(self):
+        d1_query = "SELECT Role, Segment, AVG(Usage) AS AvgUsage FROM d1.d1 GROUP BY Role, Segment"
+        d2_query = "SELECT Role, Segment, AVG(Usage) AS AvgUsage FROM d2.d2 GROUP BY Role, Segment"
+        dp_res, acc_res, utility_res, bias_res = dv.dp_groupby_query_test(d1_query, d2_query, plot=False, repeat_count=1000)
+        test_logger.debug("Result of DP Predicate Test on GROUP BY and AVG aggregate: " + str(dp_res))
+        test_logger.debug("Result of Accuracy Test on GROUP BY and AVG aggregate: " + str(acc_res))
+        test_logger.debug("Result of Utility Test on GROUP BY and AVG aggregate: " + str(utility_res))
+        test_logger.debug("Result of Bias Test on GROUP BY and AVG aggregate: " + str(bias_res))
         assert(dp_res == True)
         assert(acc_res == True)
         assert(utility_res == True)


### PR DESCRIPTION
Adding a test which computes mean signed deviation and outputs it as a ratio of actual value. If ratio is outside +/-5% of actual value (relaxed compared to 1% where it does fail quite a bit), we raise a bug as any result with so much bias on repeated querying is quite hard to consume. 

Bias becomes quite significant as records go lower, for example in Powerset test which fails right now. This is quite expect as we do want datasets with such low size to not extract meaningful unbiased results. 

Will add a hypothesis test with p-value in next PR for SUM, COUNT, MEAN, VAR operators. 